### PR TITLE
Fix wrong confirmation of overwriting

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -297,6 +297,9 @@ public abstract class MainFrame extends JFrame {
     int result = chooser.showSaveDialog(null);
     if (result == JFileChooser.APPROVE_OPTION) {
       File file = chooser.getSelectedFile();
+      if (!(file.getPath().endsWith(".sgf") || file.getPath().endsWith(".SGF"))) {
+        file = new File(file.getPath() + ".sgf");
+      }
       if (file.exists()) {
         int ret =
             JOptionPane.showConfirmDialog(
@@ -307,9 +310,6 @@ public abstract class MainFrame extends JFrame {
         if (ret == JOptionPane.CANCEL_OPTION) {
           return;
         }
-      }
-      if (!(file.getPath().endsWith(".sgf") || file.getPath().endsWith(".SGF"))) {
-        file = new File(file.getPath() + ".sgf");
       }
       try {
         SGFParser.save(Lizzie.board, file.getPath());


### PR DESCRIPTION
Congrats to your (first?) pull request https://github.com/featurecat/lizzie/pull/795 . :)

Would you merge my pull request into yours? It fixes another bug on filename extensions. We need to check overwriting AFTER adding ".sgf" if it is missing. Otherwise, when we input "foo", Lizzie will overwrite "foo.sgf" without warning.

See [GitHub Docs](https://docs.github.com/ja/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request#github-%E3%81%A7%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%82%92%E3%83%9E%E3%83%BC%E3%82%B8%E3%81%99%E3%82%8B) to merge my pull request. I recommend [Rebase and merge] in that page in this case.
